### PR TITLE
Wrap numbers in <span class="…"> tag for CSS styling

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -77,6 +77,7 @@ class syntax_plugin_autonumbering extends DokuWiki_Syntax_Plugin {
     public function handle($match, $state, $pos, Doku_Handler $handler){
         global $COUNTER;
         $counterID = '';
+        $class = 'autonumberingAll autonumbering';
         switch ($state) {
             case DOKU_LEXER_SPECIAL :
 
@@ -105,10 +106,11 @@ class syntax_plugin_autonumbering extends DokuWiki_Syntax_Plugin {
                         // Check if parent level exist
                         for ($i = 0; $i < $levelsQty; ++$i) {
                             // Check if level contain text
-                            if (ctype_alpha($dataTab[$i]))
+                            if (ctype_alpha($dataTab[$i])) {
                                 $COUNTER[$counterID][$i] = $dataTab[$i];
+                                $class .= '_' . $dataTab[$i];
                             // Search for a forced value
-                            else if (preg_match('/(' . $this->NUMBER_PATTERN . ')/', $dataTab[$i], $matches))
+                            } else if (preg_match('/(' . $this->NUMBER_PATTERN . ')/', $dataTab[$i], $matches))
                                 if ($i == $currentLevel)
                                     $COUNTER[$counterID][$i] = $matches[1]-1;
                                 else
@@ -130,12 +132,13 @@ class syntax_plugin_autonumbering extends DokuWiki_Syntax_Plugin {
                         ++$COUNTER[$counterID][$currentLevel];
 
                         // Return the number, according the level asked
-                        $number = '';
+                        $number = "<span class=\"$class\">";
                         $period = '';
                         for ($i = 0; $i < $levelsQty; ++$i) {
                             $number .= $period . $COUNTER[$counterID][$i];
                             $period = '.';
                         }
+                        $number .= '</span>';
                         return array($number, NULL);
                     } else {
                         return array($match, NULL);


### PR DESCRIPTION
I'm using the autonumbering plugin to number exercises in my teaching materials, and I wanted an `~~Exercise.#~~` to stand out.

So I added code that wraps numbers in `<span class="…">…</span>` with class `autonumberingAll` and `autonumbering[_name]...` based on text-only tokens from the autonumber tag (separated by underscore) 

This way I can add to custom CSS the following:
```.autonumbering_Exercise {style: italic; decoration: #2b73b7 underline;}```
to make the text 'Exercise.1' stand out.

I think it could be useful in general, hence the PR.

