### PR TITLE
Make '~~Exercise.#.#~~' display as 'Exercise 1.1' rather than 'Exercise.1.1'

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -134,7 +134,11 @@ class syntax_plugin_autonumbering extends DokuWiki_Syntax_Plugin {
                         $period = '';
                         for ($i = 0; $i < $levelsQty; ++$i) {
                             $number .= $period . $COUNTER[$counterID][$i];
-                            $period = '.';
+                            if (ctype_alpha($COUNTER[$counterID][$i])) {
+                                if ($period != '.')
+                                    $period = ' ';
+                            } else
+                                $period = '.';
                         }
                         return array($number, NULL);
                     } else {


### PR DESCRIPTION
I know that it's a matter of taste, but I consider e.g., 'Exercise 1.1' look better than 'Exercise.1.1' ;-)

Putting space instead of dot is done only until first non-text token is found.